### PR TITLE
move_doc_files: do not crash with which='none'

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -15,7 +15,10 @@ DOC_TYPE_FILES_MAP = {
     'sphinx': ['conf.py', 'index.rst', 'make.bat', 'Makefile']
 }
 
+
 def move_doc_files(which, map_=DOC_TYPE_FILES_MAP, doc_sources=DOC_SOURCES):
+    if which == 'none':
+        return
     root = os.getcwd()
     docs = 'docs'
     log.info('Initializing docs for %s' % which)


### PR DESCRIPTION
Fixes KeyError when selecting `'none'` with the "Select docs_tool:"
option.